### PR TITLE
docs: remind to start local PocketBase for browser QA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - `pnpm lint` - Run ESLint and Prettier checks
 - `pnpm format` - Format code with Prettier
 - Test command: Use `vitest` for testing (see src/lib/**tests**)
+- For browser verification on data-backed routes (e.g. `/recent`, `/top`, `/dash/links`), start local PocketBase first (`cd pocketbase && start-dev.bat` on Windows, or `CF_SECRET_KEY=1x0000000000000000000000000000000AA ./pocketbase serve` on Linux/macOS)
 
 ## Tech Stack
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,12 @@ pnpm dev
 # 4. Open http://127.0.0.1:5173
 ```
 
+### Browser QA Reminder
+
+If you are verifying pagination, filtering, or list behavior in Chrome DevTools on data-backed routes (like `/recent`, `/top`, and `/dash/links`), always boot local PocketBase first.
+
+Without local PocketBase running, these routes can fail to load data and UI behavior checks become unreliable.
+
 ---
 
 ## First-Time Setup


### PR DESCRIPTION
## Summary
- Add a clear reminder that local PocketBase must be running before browser verification on data-backed routes.
- Document this in both agent guidance and developer setup docs to prevent false-negative QA results.

## Changes
- Add reminder under build/test guidance in `AGENTS.md`.
- Add `Browser QA Reminder` section in `DEVELOPMENT.md`.

## Testing
- [x] Docs-only change
- [x] Verified updated markdown content renders correctly

## Context
- Follow-up from `/recent` pagination debugging session where data routes failed without local PocketBase.