### PR TITLE
feat: add maintenance windows and status CTA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,13 @@
 
 # Cloudflare Turnstile secret key
 CF_SECRET_KEY=your_cloudflare_turnstile_secret_here
+
+# Maintenance mode settings (for Cloudflare Pages environment variables)
+# PUBLIC_MAINTENANCE_MODE=false
+# Mode options: true = force on, off = force off, false/empty = follow schedule window
+# PUBLIC_MAINTENANCE_TYPE=migration
+# PUBLIC_MAINTENANCE_NOTE=link creation and dashboard edits may be temporarily unavailable.
+# PUBLIC_MAINTENANCE_SCHEDULED=2026-02-25T10:00:00Z
+# PUBLIC_MAINTENANCE_END=2026-02-25T11:00:00Z
+# PUBLIC_STATUS_PAGE_URL=https://status.sptfy.in
+# If mode is false/empty, maintenance auto-activates between SCHEDULED and END.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ this project is **not** affiliated with, endorsed by, or sponsored by Spotify AB
 
 _(TL;DR: we just like their music links, okay?)_
 
+## infrastructure notes
+
+- backend: PocketBase in Docker (`~/pb-docker`)
+- current VPS size: 2 vCPU / 2 GB RAM / 20 GB disk
+- reverse proxy: Nginx -> `127.0.0.1:8091`
+- frontend: Cloudflare Pages
+- status page: https://status.sptfy.in
+- migration runbook: `docs/MIGRATION-RUNBOOK.md`
+
 ## license
 
 this repository is licensed under [AGPL-3.0](https://github.com/ayamkv/sptfyin?tab=License-1-ov-file)

--- a/docs/MIGRATION-RUNBOOK.md
+++ b/docs/MIGRATION-RUNBOOK.md
@@ -1,0 +1,342 @@
+# PocketBase VPS Migration Runbook
+
+Emergency migration guide for moving PocketBase from one VPS to another with minimal downtime.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- [ ] New VPS running (DigitalOcean, Fly.io, Azure, etc.)
+- [ ] SSH access to both old and new VPS
+- [ ] Docker installed on new VPS
+- [ ] This repo cloned on new VPS
+
+## Current Production Setup
+
+> Security note: direct old VPS IP is intentionally redacted in repository docs.
+
+| Component          | Details                           |
+| ------------------ | --------------------------------- |
+| **Old VPS**        | IDCloudHost Jakarta (IP redacted) |
+| **Server spec**    | 2 vCPU / 2 GB RAM / 20 GB disk    |
+| **Reverse proxy**  | Nginx -> `127.0.0.1:8091`         |
+| **Data location**  | `~/pb-docker/` (~988MB)           |
+| **Docker Compose** | `~/pb-docker/docker-compose.yml`  |
+| **PocketBase URL** | `https://pbbase.sptfy.in`         |
+| **Frontend**       | Cloudflare Pages (auto-deploys)   |
+| **Status page**    | `https://status.sptfy.in`         |
+
+Webmin-related files may exist on the VPS, but the active production path is only `~/pb-docker` plus Nginx config.
+
+---
+
+## Phase 1: Pre-Migration (Do This Ahead of Time)
+
+### 1.1 Set Up New VPS
+
+```bash
+# SSH to new VPS
+ssh user@new-vps-ip
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+# Log out and back in for group to take effect
+
+# Clone the repo
+git clone https://github.com/YOUR_REPO/sptfyin.git
+cd sptfyin/pocketbase
+```
+
+### 1.2 Lower DNS TTL (Optional but Recommended)
+
+If you have time to prepare:
+
+1. Go to Cloudflare DNS for `sptfy.in`
+2. Find the A record for `pb.sptfy.in`
+3. Lower TTL to **1 minute** (or minimum allowed)
+4. Wait at least 24 hours for old TTL to expire
+
+### 1.3 Test New VPS Setup (Without Data)
+
+```bash
+# On new VPS, start PocketBase to verify Docker works
+cd ~/sptfyin/pocketbase
+docker compose up -d
+
+# Check it's running
+curl http://localhost:8091/api/health
+
+# Stop it for now
+docker compose down
+```
+
+---
+
+## Phase 2: Migration Window
+
+### 2.1 Enable Maintenance Mode
+
+**In Cloudflare Pages → Settings → Environment Variables:**
+
+```
+PUBLIC_MAINTENANCE_MODE = false
+PUBLIC_MAINTENANCE_TYPE = migration
+PUBLIC_MAINTENANCE_NOTE = Link creation is temporarily paused while infrastructure is migrated.
+PUBLIC_MAINTENANCE_SCHEDULED = 2026-02-25T10:00:00Z
+PUBLIC_MAINTENANCE_END = 2026-02-25T11:00:00Z
+PUBLIC_STATUS_PAGE_URL = https://status.sptfy.in
+```
+
+Then trigger a redeploy (push an empty commit or use Cloudflare dashboard).
+
+With `PUBLIC_MAINTENANCE_MODE=false`, maintenance auto-runs only inside the schedule window (`SCHEDULED` -> `END`).
+Manual overrides:
+
+- `PUBLIC_MAINTENANCE_MODE=true` forces maintenance ON immediately.
+- `PUBLIC_MAINTENANCE_MODE=off` forces maintenance OFF immediately.
+
+Supported `PUBLIC_MAINTENANCE_TYPE` values: `migration`, `database`, `infrastructure`, `security`, `incident`, `general`.
+Supported `PUBLIC_MAINTENANCE_MODE` values: `true`, `off`, `false` (or empty).
+
+**Verify:** Visit sptfy.in and confirm:
+
+- Maintenance toast appears
+- "Short It!" button is disabled
+- Existing redirects still work
+- "View server status" link opens your status page
+
+### 2.2 Stop Old PocketBase
+
+```bash
+# SSH to old VPS
+ssh freq@<OLD_VPS_HOST_REDACTED>
+
+# Stop PocketBase
+cd ~/pb-docker
+docker compose down
+
+# Verify it's stopped
+docker ps
+```
+
+### 2.3 Transfer Data to New VPS
+
+**Option A: Direct rsync (fastest)**
+
+```bash
+# From your local machine or old VPS
+rsync -avz --progress freq@<OLD_VPS_HOST_REDACTED>:~/pb-docker/ user@new-vps-ip:~/pb-docker/
+```
+
+**Option B: Via your local machine**
+
+```bash
+# Download from old
+rsync -avz --progress freq@<OLD_VPS_HOST_REDACTED>:~/pb-docker/ ./pb-backup/
+
+# Upload to new
+rsync -avz --progress ./pb-backup/ user@new-vps-ip:~/pb-docker/
+```
+
+**Option C: If rsync isn't available**
+
+```bash
+# On old VPS
+cd ~
+tar -czvf pb-backup.tar.gz pb-docker/
+
+# Download locally
+scp freq@<OLD_VPS_HOST_REDACTED>:~/pb-backup.tar.gz .
+
+# Upload to new VPS
+scp pb-backup.tar.gz user@new-vps-ip:~/
+
+# On new VPS
+tar -xzvf pb-backup.tar.gz
+```
+
+### 2.4 Start PocketBase on New VPS
+
+```bash
+# SSH to new VPS
+ssh user@new-vps-ip
+
+cd ~/pb-docker
+docker compose up -d
+
+# Verify it's running
+docker ps
+curl http://localhost:8091/api/health
+```
+
+### 2.5 Test via sslip.io (Instant DNS)
+
+Before switching DNS, test the new server using sslip.io:
+
+```
+http://NEW_VPS_IP.sslip.io:8091/api/health
+```
+
+Or test a redirect:
+
+```
+http://NEW_VPS_IP.sslip.io:8091/YOUR_SHORT_SLUG
+```
+
+**For HTTPS testing** (if you need it):
+
+- sslip.io supports Let's Encrypt certificates via HTTP-01 challenge
+- You can temporarily configure your frontend to point to the sslip.io domain
+
+### 2.6 Update DNS
+
+**In Cloudflare DNS:**
+
+1. Find the A record for `pb.sptfy.in`
+2. Update the IP to your new VPS IP
+3. Keep Proxy Status: **DNS only** (gray cloud) for now
+4. Save
+
+**Check propagation:**
+
+```bash
+# Should return new IP
+dig +short pb.sptfy.in
+nslookup pb.sptfy.in
+```
+
+Or use: https://www.whatsmydns.net/#A/pb.sptfy.in
+
+### 2.7 Update GitHub Actions Secrets
+
+If your deployment workflow uses VPS credentials:
+
+1. Go to GitHub → Settings → Secrets and variables → Actions
+2. Update these secrets with new VPS details:
+   - `VPS_HOST` (new IP)
+   - `VPS_USER` (if different)
+   - `VPS_SSH_KEY` (if different)
+
+### 2.8 Verify Everything Works
+
+```bash
+# Test PocketBase API via domain
+curl https://pb.sptfy.in/api/health
+
+# Test a redirect
+curl -I https://sptfy.in/YOUR_TEST_SLUG
+```
+
+---
+
+## Phase 3: Post-Migration
+
+### 3.1 Disable Maintenance Mode
+
+**In Cloudflare Pages → Environment Variables:**
+
+```
+PUBLIC_MAINTENANCE_MODE = false
+PUBLIC_MAINTENANCE_TYPE = (clear/delete)
+PUBLIC_MAINTENANCE_NOTE = (clear/delete)
+PUBLIC_MAINTENANCE_SCHEDULED = (clear/delete)
+PUBLIC_MAINTENANCE_END = (clear/delete)
+PUBLIC_STATUS_PAGE_URL = (optional, keep default or clear)
+```
+
+If you need to immediately bypass a scheduled window, set `PUBLIC_MAINTENANCE_MODE = off`.
+
+Trigger redeploy.
+
+### 3.2 Verify Full Functionality
+
+- [ ] Create a new short link (homepage)
+- [ ] Create a short link (dashboard, if logged in)
+- [ ] Test a redirect
+- [ ] Check recent/top pages load
+
+### 3.3 Restore DNS TTL
+
+In Cloudflare DNS, set TTL back to **Auto** or your preferred value.
+
+### 3.4 Monitor for Issues
+
+Check for errors in:
+
+- Cloudflare Pages deployment logs
+- New VPS Docker logs: `docker compose logs -f`
+- BetterStack or your monitoring tool
+
+---
+
+## Rollback Procedure
+
+If something goes wrong:
+
+### Quick Rollback (< 30 min into migration)
+
+```bash
+# Stop new VPS PocketBase
+ssh user@new-vps-ip
+cd ~/pb-docker && docker compose down
+
+# Restart old VPS PocketBase
+ssh freq@<OLD_VPS_HOST_REDACTED>
+cd ~/pb-docker && docker compose up -d
+
+# Revert DNS to old IP
+# (In Cloudflare DNS)
+
+# Keep maintenance mode on until confirmed working
+```
+
+### If Data Was Modified on New Server
+
+You'll need to decide:
+
+1. **Accept data loss**: Revert to old server, lose any links created on new
+2. **Forward-fix**: Debug and fix the issue on new server
+3. **Merge data**: Export new data, merge with old, restore (complex)
+
+---
+
+## Emergency Contacts
+
+- **Primary**: @ayamkv
+- **Monitoring**: BetterStack status page
+
+---
+
+## Appendix: Useful Commands
+
+### Docker Commands
+
+```bash
+# View logs
+docker compose logs -f
+
+# Restart PocketBase
+docker compose restart
+
+# Check container status
+docker ps
+
+# Enter container shell
+docker compose exec pocketbase sh
+```
+
+### PocketBase Admin
+
+- Admin UI: `https://pb.sptfy.in/_/`
+- API health: `https://pb.sptfy.in/api/health`
+
+### Cloudflare Pages
+
+- Dashboard: https://dash.cloudflare.com
+- Environment variables: Pages → sptfyin → Settings → Environment variables
+
+### Backup Locations
+
+- Automated backups: Cloudflare R2 (via PocketBase backup feature)
+- Manual backup on old VPS: `~/pb_backup_oct.zip`

--- a/src/lib/components/maintenance-toast.svelte
+++ b/src/lib/components/maintenance-toast.svelte
@@ -1,0 +1,123 @@
+<script>
+	import { onMount } from 'svelte';
+	import {
+		getMaintenanceState,
+		getTimeRemaining,
+		formatTimeRemaining,
+		getStatusPageUrl
+	} from '$lib/maintenance.js';
+
+	let state = $state(getMaintenanceState());
+	let dismissed = $state(false);
+	let countdown = $state(null);
+	let hydrated = $state(false);
+
+	const STORAGE_KEY_PREFIX = 'maintenance_dismissed_';
+	const statusPageUrl = getStatusPageUrl();
+
+	function getStorageKey() {
+		return STORAGE_KEY_PREFIX + (state.message || '');
+	}
+
+	function dismiss() {
+		dismissed = true;
+		if (state.status !== 'scheduled') return;
+
+		try {
+			localStorage.setItem(getStorageKey(), 'true');
+		} catch {
+			// localStorage might not be available
+		}
+	}
+
+	function updateCountdown() {
+		if (state.status === 'scheduled' && state.scheduledDate) {
+			const remaining = getTimeRemaining(state.scheduledDate);
+			if (remaining.total > 0) {
+				countdown = `will start in ${formatTimeRemaining(remaining)}`;
+			} else {
+				// Maintenance time reached, refresh state
+				state = getMaintenanceState();
+				countdown = null;
+			}
+		} else {
+			countdown = null;
+		}
+	}
+
+	onMount(() => {
+		// Check if this specific message was dismissed
+		if (state.status === 'scheduled') {
+			try {
+				const wasDismissed = localStorage.getItem(getStorageKey());
+				if (wasDismissed === 'true') {
+					dismissed = true;
+				}
+			} catch {
+				// localStorage might not be available
+			}
+		}
+
+		// Initial countdown update
+		updateCountdown();
+		hydrated = true;
+
+		if (state.status !== 'scheduled' || !state.scheduledDate) {
+			return;
+		}
+
+		const interval = setInterval(() => {
+			updateCountdown();
+			if (state.status !== 'scheduled' || !state.scheduledDate) {
+				clearInterval(interval);
+			}
+		}, 1000);
+
+		return () => clearInterval(interval);
+	});
+</script>
+
+{#if hydrated && state.status !== 'normal' && !dismissed}
+	<div class="fixed left-1/2 top-4 z-[100] w-full max-w-md -translate-x-1/2 px-4">
+		<div
+			class="flex items-center gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm {state.status ===
+			'active'
+				? 'border-red-500/30 bg-red-500/10 text-red-200'
+				: 'border-amber-500/30 bg-amber-500/10 text-amber-200'}"
+		>
+			{#if state.status === 'active'}
+				<iconify-icon icon="lucide:construction" class="shrink-0 text-xl"></iconify-icon>
+			{:else}
+				<iconify-icon icon="lucide:alert-triangle" class="shrink-0 text-xl"></iconify-icon>
+			{/if}
+
+			<div class="min-w-0 flex-1">
+				<span class="font-medium">{state.message}</span>
+				{#if countdown}
+					<div class="text-sm opacity-80">{countdown}</div>
+				{/if}
+				{#if state.note}
+					<div class="text-sm opacity-80">{state.note}</div>
+				{/if}
+				<div class="mt-1 text-sm opacity-80">
+					<a
+						href={statusPageUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="transition-opacity hover:underline hover:opacity-100"
+					>
+						view server status
+					</a>
+				</div>
+			</div>
+
+			<button
+				onclick={dismiss}
+				class="shrink-0 rounded p-1 transition-colors hover:bg-white/10"
+				aria-label="Dismiss notification"
+			>
+				<iconify-icon icon="lucide:x" class="text-lg"></iconify-icon>
+			</button>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/ui/toggle/toggle.svelte
+++ b/src/lib/components/ui/toggle/toggle.svelte
@@ -7,7 +7,8 @@
 			variant: {
 				default: 'bg-transparent hover:bg-muted data-[state=on]:bg-accent',
 				outline: 'border-input hover:bg-accent hover:text-accent-foreground border bg-transparent',
-				ghost: 'border border-secondary/20 shadow-md hover:bg-accent hover:text-accent-foreground hover:bg-secondary/80 hover:outline-primary hover:inverseShadow active:scale-95 transition-all data-[state=on]:text-accent-foreground data-[state=on]:bg-background/30 data-[state=on]:inverseShadow',
+				ghost:
+					'border border-secondary/20 shadow-md hover:bg-accent hover:text-accent-foreground hover:bg-secondary/80 hover:outline-primary hover:inverseShadow active:scale-95 transition-all data-[state=on]:text-accent-foreground data-[state=on]:bg-background/30 data-[state=on]:inverseShadow',
 				ghost2:
 					'bg-gradient-to-br from-[#302D3A] via-5% text-secondary-foreground hover:text-accent-foreground hover:bg-secondary/40 hover:inverseShadow highlightSecondary active:scale-95 transition-all data-[state=on]:text-accent-foreground data-[state=on]:bg-background/30 data-[state=on]:inverseShadow border-t'
 			},

--- a/src/lib/maintenance.js
+++ b/src/lib/maintenance.js
@@ -1,0 +1,227 @@
+/**
+ * Maintenance mode utilities
+ *
+ * Environment variables (set in Cloudflare Pages or .env):
+ * - PUBLIC_MAINTENANCE_MODE: "true" | "off" | "false" - true forces on, off forces off, false/empty uses schedule
+ * - PUBLIC_MAINTENANCE_TYPE: migration | database | infrastructure | security | incident | general
+ * - PUBLIC_MAINTENANCE_NOTE: optional extra context shown under the status message
+ * - PUBLIC_MAINTENANCE_SCHEDULED: ISO date string - Start time
+ * - PUBLIC_MAINTENANCE_END: ISO date string - End time (optional)
+ * - PUBLIC_STATUS_PAGE_URL: optional status page URL (defaults to https://status.sptfy.in)
+ */
+
+import { env } from '$env/dynamic/public';
+
+const MAINTENANCE_TYPES = {
+	migration: 'migration',
+	database: 'database',
+	infrastructure: 'infrastructure',
+	security: 'security',
+	incident: 'incident',
+	general: 'general'
+};
+
+/**
+ * Get normalized maintenance type
+ * @returns {'migration' | 'database' | 'infrastructure' | 'security' | 'incident' | 'general'}
+ */
+export function getMaintenanceType() {
+	const type = (env.PUBLIC_MAINTENANCE_TYPE || '').trim().toLowerCase();
+	return MAINTENANCE_TYPES[type] ? type : 'general';
+}
+
+/**
+ * Get human-readable maintenance type label
+ * @returns {string}
+ */
+export function getMaintenanceTypeLabel() {
+	return MAINTENANCE_TYPES[getMaintenanceType()];
+}
+
+/**
+ * Get normalized maintenance mode
+ * @returns {'force_on' | 'force_off' | 'auto'}
+ */
+export function getMaintenanceMode() {
+	const mode = (env.PUBLIC_MAINTENANCE_MODE || '').trim().toLowerCase();
+
+	if (mode === 'true') return 'force_on';
+	if (mode === 'off') return 'force_off';
+
+	return 'auto';
+}
+
+/**
+ * Check if maintenance mode is currently active
+ * @returns {boolean}
+ */
+export function isMaintenanceActive(now = Date.now()) {
+	const mode = getMaintenanceMode();
+	if (mode === 'force_on') return true;
+	if (mode === 'force_off') return false;
+
+	const startDate = getScheduledMaintenanceDate();
+	if (!startDate) return false;
+
+	if (startDate.getTime() > now) return false;
+
+	const endDate = getMaintenanceEndDate();
+	if (endDate && endDate.getTime() <= startDate.getTime()) {
+		return true;
+	}
+
+	if (endDate && now >= endDate.getTime()) return false;
+
+	return true;
+}
+
+/**
+ * Get maintenance status message
+ * @param {'active' | 'scheduled'} status
+ * @returns {string}
+ */
+export function getMaintenanceMessage(status) {
+	const typeLabel = getMaintenanceTypeLabel();
+
+	if (status === 'scheduled') {
+		return `${typeLabel} maintenance will start soon.`;
+	}
+
+	return `${typeLabel} maintenance is in progress. Link creation is temporarily disabled.`;
+}
+
+/**
+ * Get optional maintenance note
+ * @returns {string | null}
+ */
+export function getMaintenanceNote() {
+	const note = env.PUBLIC_MAINTENANCE_NOTE;
+	return note && note.trim() ? note.trim() : null;
+}
+
+/**
+ * Get status page URL
+ * @returns {string}
+ */
+export function getStatusPageUrl() {
+	const url = env.PUBLIC_STATUS_PAGE_URL;
+	return url && url.trim() ? url.trim() : 'https://status.sptfy.in';
+}
+
+/**
+ * Get the scheduled maintenance date, if any
+ * @returns {Date | null}
+ */
+export function getScheduledMaintenanceDate() {
+	const scheduled = env.PUBLIC_MAINTENANCE_SCHEDULED;
+	if (!scheduled || !scheduled.trim()) return null;
+
+	const date = new Date(scheduled);
+	if (isNaN(date.getTime())) return null;
+
+	return date;
+}
+
+/**
+ * Get the scheduled maintenance end date, if any
+ * @returns {Date | null}
+ */
+export function getMaintenanceEndDate() {
+	const scheduledEnd = env.PUBLIC_MAINTENANCE_END;
+	if (!scheduledEnd || !scheduledEnd.trim()) return null;
+
+	const date = new Date(scheduledEnd);
+	if (isNaN(date.getTime())) return null;
+
+	return date;
+}
+
+/**
+ * Check if there's upcoming scheduled maintenance (not yet active)
+ * @returns {boolean}
+ */
+export function hasScheduledMaintenance(now = Date.now()) {
+	const mode = getMaintenanceMode();
+	if (mode !== 'auto') return false;
+
+	if (isMaintenanceActive(now)) return false; // Already active, not "scheduled"
+
+	const scheduled = getScheduledMaintenanceDate();
+	if (!scheduled) return false;
+
+	return scheduled.getTime() > now;
+}
+
+/**
+ * Get the current maintenance state
+ * @returns {{ status: 'normal' | 'scheduled' | 'active', type: string | null, message: string | null, note: string | null, scheduledDate: Date | null, endDate: Date | null }}
+ */
+export function getMaintenanceState(now = Date.now()) {
+	const type = getMaintenanceType();
+	const note = getMaintenanceNote();
+	const scheduledDate = getScheduledMaintenanceDate();
+	const endDate = getMaintenanceEndDate();
+
+	if (isMaintenanceActive(now)) {
+		return {
+			status: 'active',
+			type,
+			message: getMaintenanceMessage('active'),
+			note,
+			scheduledDate,
+			endDate
+		};
+	}
+
+	if (hasScheduledMaintenance(now)) {
+		return {
+			status: 'scheduled',
+			type,
+			message: getMaintenanceMessage('scheduled'),
+			note,
+			scheduledDate,
+			endDate
+		};
+	}
+
+	return {
+		status: 'normal',
+		type: null,
+		message: null,
+		note: null,
+		scheduledDate: null,
+		endDate: null
+	};
+}
+
+/**
+ * Calculate time remaining until scheduled maintenance
+ * @param {Date} targetDate
+ * @returns {{ days: number, hours: number, minutes: number, seconds: number, total: number }}
+ */
+export function getTimeRemaining(targetDate) {
+	const total = Math.max(0, targetDate.getTime() - Date.now());
+
+	const seconds = Math.floor((total / 1000) % 60);
+	const minutes = Math.floor((total / 1000 / 60) % 60);
+	const hours = Math.floor((total / (1000 * 60 * 60)) % 24);
+	const days = Math.floor(total / (1000 * 60 * 60 * 24));
+
+	return { days, hours, minutes, seconds, total };
+}
+
+/**
+ * Format time remaining as a human-readable string
+ * @param {{ days: number, hours: number, minutes: number, seconds: number }} time
+ * @returns {string}
+ */
+export function formatTimeRemaining({ days, hours, minutes, seconds }) {
+	const parts = [];
+
+	if (days > 0) parts.push(`${days}d`);
+	if (hours > 0) parts.push(`${hours}h`);
+	if (minutes > 0) parts.push(`${minutes}m`);
+	if (days === 0 && hours === 0) parts.push(`${seconds}s`); // Only show seconds if < 1 hour
+
+	return parts.join(' ') || '0s';
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { Home, CircleUserRound, HandHeart, Info, History, Trophy } from 'lucide-svelte';
 	import { page } from '$app/stores';
 	import logo from '$lib/images/logo.png';
+	import MaintenanceToast from '$lib/components/maintenance-toast.svelte';
 
 	import { onMount } from 'svelte';
 	/**
@@ -85,6 +86,7 @@
 </script>
 
 <Toaster duration={4000} position="top-center" />
+<MaintenanceToast />
 
 <!-- Global background noise overlay (z-index behind content) -->
 <!-- <BackgroundNoise baseFrequency={0.8} numOctaves={2} scale={1} /> -->

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,6 +24,7 @@
 		isSpotifyShortLink,
 		formatNumber
 	} from '$lib/utils';
+	import { isMaintenanceActive } from '$lib/maintenance';
 	import { WithEase } from '$lib/animations/customSpring';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Drawer from '$lib/components/ui/drawer/index.js';
@@ -70,6 +71,8 @@
 	let reset = $state();
 	let preGeneratedUrlId = $state();
 	let lastCreatedShortId = $state();
+	let maintenanceNow = $state(Date.now());
+	let maintenanceActive = $derived(isMaintenanceActive(maintenanceNow));
 
 	// Domain selection must be defined before QR derivations
 	let selected = $state('sptfy.in');
@@ -258,6 +261,14 @@
 		isOldFirefox = ua.includes('firefox/') && ua.split('firefox/')[1].split('.')[0] < 103;
 		// console log the ua user is using
 		console.log(getBrowserName());
+	});
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			maintenanceNow = Date.now();
+		}, 1000);
+
+		return () => clearInterval(interval);
 	});
 
 	/**
@@ -488,7 +499,7 @@
 				slugAvailable === false ||
 				!!slugCheckError)
 	);
-	let buttonDisabled = $derived(loading || customSlugInvalidOrChecking);
+	let buttonDisabled = $derived(loading || customSlugInvalidOrChecking || maintenanceActive);
 
 	// Debounced availability check when sanitizedCustomShortId changes
 	$effect(() => {
@@ -864,7 +875,7 @@
 		</Dialog.Content>
 	</Dialog.Root>
 
-	<div class="logo mt-[20em] md:mb-6 flex flex-col items-center justify-center md:mt-[2em]">
+	<div class="logo mt-[20em] flex flex-col items-center justify-center md:mb-6 md:mt-[2em]">
 		<!-- Sticker-style stats badges positioned around the title -->
 		<div class="relative">
 			<!-- Cat sticker - top left -->
@@ -973,7 +984,7 @@
 										? 'Expanding link...'
 										: 'https://open.spotify.com/xxxx....'}
 									bind:value={inputText}
-									class="placeholder:translate-y-[2px] rounded-xl"
+									class="rounded-xl placeholder:translate-y-[2px]"
 									required
 									autofocus
 									disabled={isExpandingUrl}
@@ -981,7 +992,7 @@
 								<Button
 									type="button"
 									id="paste"
-									class="paste-button hover:bg-primary rounded-xl hover:from-[#afffdc]/20 hover:text-black"
+									class="paste-button rounded-xl hover:bg-primary hover:from-[#afffdc]/20 hover:text-black"
 									variant="ghost3"
 									onclick={() => handlePaste()}
 									disabled={isExpandingUrl}
@@ -1028,7 +1039,7 @@
 											: 'pointer-events-none translate-x-full opacity-0'}"
 									>
 										<Select.Root type="single" name="domainSelect" bind:value={selected}>
-											<Select.Trigger class="h-8 w-[140px] text-xs rounded-xl">
+											<Select.Trigger class="h-8 w-[140px] rounded-xl text-xs">
 												{selectedLabel || 'sptfy.in'}
 											</Select.Trigger>
 											<Select.Portal>
@@ -1055,7 +1066,7 @@
 											placeholder={shortIdDisplay}
 											bind:value={customShortId}
 											oninput={(e) => updateCustomShortId(e.currentTarget.value)}
-											class={'mr-2 h-8 flex-1 text-xs placeholder:translate-y-[2px] rounded-xl ' +
+											class={'mr-2 h-8 flex-1 rounded-xl text-xs placeholder:translate-y-[2px] ' +
 												slugInputClass}
 										/>
 									</div>
@@ -1124,7 +1135,7 @@
 							{/if}
 							<div class="mt-4">
 								<Button
-									class="submit-button align-center m-auto rounded-xl flex w-full flex-row items-center justify-center gap-2 text-center
+									class="submit-button align-center m-auto flex w-full flex-row items-center justify-center gap-2 rounded-xl text-center
 								{loading ? 'bg-secondary text-foreground shadow-lg' : ''}
 								transition-all"
 									type="submit"
@@ -1140,11 +1151,13 @@
 										width="18"
 									></iconify-icon>
 									<span class="flex-1"
-										>{loading
-											? 'loading...'
-											: turnstileStatus !== 'verified'
-												? 'validating...'
-												: 'short It!'}</span
+										>{maintenanceActive
+											? 'maintenance...'
+											: loading
+												? 'loading...'
+												: turnstileStatus !== 'verified'
+													? 'validating...'
+													: 'short It!'}</span
 									>
 									<!-- Right indicator: Turnstile verification status -->
 									{#if !loading}
@@ -1369,7 +1382,7 @@
 					</ToggleGroup.Root>
 					<a
 						href={activeTab === 'recent' ? '/recent' : '/top'}
-						class="inline-flex h-10 items-center justify-center whitespace-nowrap rounded-xl border-t px-4 py-2 text-sm font-thin text-secondary-foreground no-underline border border-secondary/20 shadow-md hover:bg-accent hover:text-accent-foreground hover:bg-secondary/80 hover:outline-primary hover:inverseShadow active:scale-95 transition-all data-[state=on]:text-accent-foreground data-[state=on]:bg-background/30 data-[state=on]:inverseShadow"
+						class="hover:inverseShadow data-[state=on]:inverseShadow inline-flex h-10 items-center justify-center whitespace-nowrap rounded-xl border border-t border-secondary/20 px-4 py-2 text-sm font-thin text-secondary-foreground no-underline shadow-md transition-all hover:bg-accent hover:bg-secondary/80 hover:text-accent-foreground hover:outline-primary active:scale-95 data-[state=on]:bg-background/30 data-[state=on]:text-accent-foreground"
 					>
 						view all
 					</a>

--- a/src/routes/api/links/+server.js
+++ b/src/routes/api/links/+server.js
@@ -1,5 +1,6 @@
 import { json, error } from '@sveltejs/kit';
 import { generateRandomURL } from '$lib/pocketbase';
+import { isMaintenanceActive, getMaintenanceState } from '$lib/maintenance';
 const pocketBaseURL = import.meta.env.VITE_POCKETBASE_URL;
 
 export async function GET({ locals, url, fetch }) {
@@ -45,6 +46,12 @@ export async function GET({ locals, url, fetch }) {
 }
 
 export async function POST({ locals, request }) {
+	// Check maintenance mode first
+	if (isMaintenanceActive()) {
+		const state = getMaintenanceState();
+		throw error(503, state.message || 'Service temporarily unavailable for maintenance');
+	}
+
 	const body = await request.json();
 	const { from, slug, subdomain, turnstileToken } = body || {};
 	if (!from) throw error(400, 'from is required');

--- a/src/routes/dash/links/+page.svelte
+++ b/src/routes/dash/links/+page.svelte
@@ -15,6 +15,7 @@
 	import { strings } from '$lib/localization/languages/en.json';
 	import { findUrl, isSpotifyShortLink } from '$lib/utils';
 	import { generateRandomURL } from '$lib/pocketbase';
+	import { isMaintenanceActive } from '$lib/maintenance';
 	import * as Drawer from '$lib/components/ui/drawer';
 	import { Switch } from '$lib/components/ui/switch';
 	import { Label } from '$lib/components/ui/label';
@@ -44,6 +45,8 @@
 	let reset = $state();
 	let createDialogOpen = $state(false);
 	let loading = $state(false);
+	let maintenanceNow = $state(Date.now());
+	let maintenanceActive = $derived(isMaintenanceActive(maintenanceNow));
 	const user = data.user;
 
 	// Edit mode and pre-generation
@@ -204,6 +207,14 @@
 		return () => {
 			window.removeEventListener('resize', handleResize);
 		};
+	});
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			maintenanceNow = Date.now();
+		}, 1000);
+
+		return () => clearInterval(interval);
 	});
 
 	// Fetch previews for all links in the list
@@ -1542,8 +1553,8 @@
 		</div>
 		<Dialog.Footer>
 			<Button variant="outline" onclick={() => (createDialogOpen = false)}>Cancel</Button>
-			<Button onclick={createLink} disabled={loading}>
-				{loading ? 'Creating...' : 'Create Link'}
+			<Button onclick={createLink} disabled={loading || maintenanceActive}>
+				{maintenanceActive ? 'Maintenance...' : loading ? 'Creating...' : 'Create Link'}
 			</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
@@ -1606,7 +1617,11 @@ bg-background/40 pb-16 sm:pb-0 md:max-h-[96vh] md:min-h-[96vh] md:rounded-xl md:
 					<Button variant="outline" onclick={refreshLinks} class="gap-2">
 						<iconify-icon icon="lucide:refresh-cw" width="16"></iconify-icon>
 					</Button>
-					<Button onclick={() => (createDialogOpen = true)} class="gap-2">
+					<Button
+						onclick={() => (createDialogOpen = true)}
+						class="gap-2"
+						disabled={maintenanceActive}
+					>
 						<Plus class="h-4 w-4" />
 					</Button>
 				</div>
@@ -1659,7 +1674,12 @@ bg-background/40 pb-16 sm:pb-0 md:max-h-[96vh] md:min-h-[96vh] md:rounded-xl md:
 				{#if items.length === 0}
 					<div class="py-8 text-center text-muted-foreground">
 						<p class="mb-2">no links created yet</p>
-						<Button variant="outline" onclick={() => (createDialogOpen = true)} class="gap-2">
+						<Button
+							variant="outline"
+							onclick={() => (createDialogOpen = true)}
+							class="gap-2"
+							disabled={maintenanceActive}
+						>
 							<Plus class="h-4 w-4" />
 							create your first link
 						</Button>


### PR DESCRIPTION
## Summary
- add a configurable maintenance system with typed messages, scheduled start/end windows, and manual overrides (`true` to force on, `off` to force off)
- add a global maintenance toast with countdown, optional note text, and a "View server status" CTA that links to the status page
- enforce maintenance lock on link creation routes while keeping existing redirects functional, and document the migration/maintenance flow in a runbook

## Testing
- pnpm build
- manual browser verification with Chrome DevTools for scheduled, active, auto-end, and manual-off behaviors