### PR TITLE
fix: minimize migration maintenance toast instead of dismissing

### DIFF
--- a/src/lib/components/maintenance-toast.svelte
+++ b/src/lib/components/maintenance-toast.svelte
@@ -9,14 +9,21 @@
 
 	let state = $state(getMaintenanceState());
 	let dismissed = $state(false);
+	let minimized = $state(false);
 	let countdown = $state(null);
 	let hydrated = $state(false);
 
 	const STORAGE_KEY_PREFIX = 'maintenance_dismissed_';
+	const MINIMIZED_STORAGE_KEY_PREFIX = 'maintenance_minimized_';
 	const statusPageUrl = getStatusPageUrl();
+	const isMigration = $derived(state.type === 'migration');
 
 	function getStorageKey() {
 		return STORAGE_KEY_PREFIX + (state.message || '');
+	}
+
+	function getMinimizedStorageKey() {
+		return MINIMIZED_STORAGE_KEY_PREFIX + (state.message || '');
 	}
 
 	function dismiss() {
@@ -30,6 +37,28 @@
 		}
 	}
 
+	function toggleMinimized() {
+		if (!isMigration) {
+			dismiss();
+			return;
+		}
+
+		const nextMinimized = !minimized;
+		minimized = nextMinimized;
+
+		if (state.status !== 'scheduled') return;
+
+		try {
+			if (nextMinimized) {
+				localStorage.setItem(getMinimizedStorageKey(), 'true');
+			} else {
+				localStorage.removeItem(getMinimizedStorageKey());
+			}
+		} catch {
+			// localStorage might not be available
+		}
+	}
+
 	function updateCountdown() {
 		if (state.status === 'scheduled' && state.scheduledDate) {
 			const remaining = getTimeRemaining(state.scheduledDate);
@@ -38,6 +67,9 @@
 			} else {
 				// Maintenance time reached, refresh state
 				state = getMaintenanceState();
+				if (state.status === 'active' && state.type === 'migration') {
+					minimized = false;
+				}
 				countdown = null;
 			}
 		} else {
@@ -49,9 +81,16 @@
 		// Check if this specific message was dismissed
 		if (state.status === 'scheduled') {
 			try {
-				const wasDismissed = localStorage.getItem(getStorageKey());
-				if (wasDismissed === 'true') {
-					dismissed = true;
+				if (state.type === 'migration') {
+					const wasMinimized = localStorage.getItem(getMinimizedStorageKey());
+					if (wasMinimized === 'true') {
+						minimized = true;
+					}
+				} else {
+					const wasDismissed = localStorage.getItem(getStorageKey());
+					if (wasDismissed === 'true') {
+						dismissed = true;
+					}
 				}
 			} catch {
 				// localStorage might not be available
@@ -77,7 +116,7 @@
 	});
 </script>
 
-{#if hydrated && state.status !== 'normal' && !dismissed}
+{#if hydrated && state.status !== 'normal' && (isMigration || !dismissed)}
 	<div class="fixed left-1/2 top-4 z-[100] w-full max-w-md -translate-x-1/2 px-4">
 		<div
 			class="flex items-center gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur-sm {state.status ===
@@ -92,32 +131,57 @@
 			{/if}
 
 			<div class="min-w-0 flex-1">
-				<span class="font-medium">{state.message}</span>
-				{#if countdown}
-					<div class="text-sm opacity-80">{countdown}</div>
-				{/if}
-				{#if state.note}
-					<div class="text-sm opacity-80">{state.note}</div>
-				{/if}
-				<div class="mt-1 text-sm opacity-80">
-					<a
-						href={statusPageUrl}
-						target="_blank"
-						rel="noopener noreferrer"
-						class="transition-opacity hover:underline hover:opacity-100"
+				{#if !isMigration || !minimized}
+					<span class="font-medium">{state.message}</span>
+					{#if countdown}
+						<div class="text-sm opacity-80">{countdown}</div>
+					{/if}
+					{#if state.note}
+						<div class="text-sm opacity-80">{state.note}</div>
+					{/if}
+					<div class="mt-1 text-sm opacity-80">
+						<a
+							href={statusPageUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="transition-opacity hover:underline hover:opacity-100"
+						>
+							view server status
+						</a>
+					</div>
+				{:else}
+					<span class="font-medium"
+						>{state.status === 'active'
+							? 'Migration maintenance in progress.'
+							: 'Migration maintenance starts soon.'}</span
 					>
-						view server status
-					</a>
-				</div>
+					{#if countdown}
+						<div class="text-sm opacity-80">{countdown}</div>
+					{/if}
+				{/if}
 			</div>
 
-			<button
-				onclick={dismiss}
-				class="shrink-0 rounded p-1 transition-colors hover:bg-white/10"
-				aria-label="Dismiss notification"
-			>
-				<iconify-icon icon="lucide:x" class="text-lg"></iconify-icon>
-			</button>
+			{#if isMigration}
+				<button
+					onclick={toggleMinimized}
+					class="shrink-0 rounded p-1 transition-colors hover:bg-white/10"
+					aria-label={minimized
+						? 'Expand migration maintenance notice'
+						: 'Minimize migration maintenance notice'}
+					aria-expanded={!minimized}
+				>
+					<iconify-icon icon={minimized ? 'lucide:maximize-2' : 'lucide:minimize-2'} class="text-lg"
+					></iconify-icon>
+				</button>
+			{:else}
+				<button
+					onclick={dismiss}
+					class="shrink-0 rounded p-1 transition-colors hover:bg-white/10"
+					aria-label="Dismiss notification"
+				>
+					<iconify-icon icon="lucide:x" class="text-lg"></iconify-icon>
+				</button>
+			{/if}
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
## Summary
- Replace the migration maintenance toast close action with minimize/expand so users still see maintenance status.
- Keep non-migration maintenance notices dismissible with the existing `X` button behavior.
- Persist scheduled migration minimized state and auto-expand when maintenance transitions from scheduled to active.

## Testing
- [x] Manual UI verification in Chrome DevTools (desktop + mobile viewport)
- [x] `pnpm lint`
- [x] `pnpm build`