### PR TITLE
chore: pin PocketBase image and refresh migration runbook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 
 services:
   pocketbase:
-    image: ghcr.io/muchobien/pocketbase:latest
+    image: ghcr.io/muchobien/pocketbase:0.23.12
     tty: true
     container_name: pocketbase
     restart: unless-stopped

--- a/docs/MIGRATION-RUNBOOK.md
+++ b/docs/MIGRATION-RUNBOOK.md
@@ -1,342 +1,249 @@
-# PocketBase VPS Migration Runbook
+# PocketBase VPS Migration Runbook (v2)
 
-Emergency migration guide for moving PocketBase from one VPS to another with minimal downtime.
+Battle-tested migration guide for moving PocketBase between VPS providers with minimal downtime and a clean rollback path.
 
-## Prerequisites
+## Goal
 
-Before starting, ensure you have:
-
-- [ ] New VPS running (DigitalOcean, Fly.io, Azure, etc.)
-- [ ] SSH access to both old and new VPS
-- [ ] Docker installed on new VPS
-- [ ] This repo cloned on new VPS
-
-## Current Production Setup
-
-> Security note: direct old VPS IP is intentionally redacted in repository docs.
-
-| Component          | Details                           |
-| ------------------ | --------------------------------- |
-| **Old VPS**        | IDCloudHost Jakarta (IP redacted) |
-| **Server spec**    | 2 vCPU / 2 GB RAM / 20 GB disk    |
-| **Reverse proxy**  | Nginx -> `127.0.0.1:8091`         |
-| **Data location**  | `~/pb-docker/` (~988MB)           |
-| **Docker Compose** | `~/pb-docker/docker-compose.yml`  |
-| **PocketBase URL** | `https://pbbase.sptfy.in`         |
-| **Frontend**       | Cloudflare Pages (auto-deploys)   |
-| **Status page**    | `https://status.sptfy.in`         |
-
-Webmin-related files may exist on the VPS, but the active production path is only `~/pb-docker` plus Nginx config.
+- Keep redirect service available for users
+- Freeze write traffic only for a short cutover window
+- Avoid silent data drift during final sync
+- Preserve a fast rollback path
 
 ---
 
-## Phase 1: Pre-Migration (Do This Ahead of Time)
+## Current Production Context
 
-### 1.1 Set Up New VPS
+| Component              | Details                              |
+| ---------------------- | ------------------------------------ |
+| Backend runtime        | PocketBase in Docker (`~/pb-docker`) |
+| Reverse proxy          | Nginx -> `127.0.0.1:8091`            |
+| Primary backend domain | `https://pb.sptfy.in`                |
+| Legacy backend domain  | `https://pbbase.sptfy.in`            |
+| Frontend               | Cloudflare Pages                     |
+| Status page            | `https://status.sptfy.in`            |
+
+> Security note: keep direct VPS IPs out of committed docs.
+
+---
+
+## 0) Fill Variables First
+
+Set these values in your shell/session notes before starting.
+
+- `OLD_HOST` old VPS IP/host
+- `NEW_HOST` new VPS IP/host
+- `OLD_USER` old VPS user
+- `NEW_USER` new VPS user
+- `APP_DIR=~/pb-docker`
+- `PB_DOMAIN=pb.sptfy.in`
+- `PB_IMAGE_PIN=ghcr.io/muchobien/pocketbase:0.23.12` (or current production version)
+
+---
+
+## 1) Pre-Flight Checklist (must all pass)
+
+- [ ] SSH to both old and new VPS works
+- [ ] Docker + Compose installed on new VPS
+- [ ] Repo cloned to `~/pb-docker` on new VPS
+- [ ] `docker-compose.yml` image pinned (no `latest` during migration)
+- [ ] New VPS has `.env` with required secrets (`CF_SECRET_KEY`)
+- [ ] Nginx configured on new VPS for `pb.sptfy.in` -> `127.0.0.1:8091`
+- [ ] TLS cert valid on new VPS (`certbot`)
+- [ ] NSG inbound allows only `22`, `80`, `443`
+- [ ] SSH deploy key for GitHub Actions tested
+- [ ] Optional but recommended: 2G swap enabled on 1G RAM VM
+
+Recommended quick checks:
 
 ```bash
-# SSH to new VPS
-ssh user@new-vps-ip
-
-# Install Docker
-curl -fsSL https://get.docker.com | sh
-sudo usermod -aG docker $USER
-# Log out and back in for group to take effect
-
-# Clone the repo
-git clone https://github.com/YOUR_REPO/sptfyin.git
-cd sptfyin/pocketbase
-```
-
-### 1.2 Lower DNS TTL (Optional but Recommended)
-
-If you have time to prepare:
-
-1. Go to Cloudflare DNS for `sptfy.in`
-2. Find the A record for `pb.sptfy.in`
-3. Lower TTL to **1 minute** (or minimum allowed)
-4. Wait at least 24 hours for old TTL to expire
-
-### 1.3 Test New VPS Setup (Without Data)
-
-```bash
-# On new VPS, start PocketBase to verify Docker works
-cd ~/sptfyin/pocketbase
-docker compose up -d
-
-# Check it's running
-curl http://localhost:8091/api/health
-
-# Stop it for now
-docker compose down
+docker compose version
+grep 'image:' docker-compose.yml
+sudo nginx -t
+sudo certbot certificates
+free -h
+df -h
 ```
 
 ---
 
-## Phase 2: Migration Window
+## 2) Warm Sync (No Downtime)
 
-### 2.1 Enable Maintenance Mode
-
-**In Cloudflare Pages → Settings → Environment Variables:**
-
-```
-PUBLIC_MAINTENANCE_MODE = false
-PUBLIC_MAINTENANCE_TYPE = migration
-PUBLIC_MAINTENANCE_NOTE = Link creation is temporarily paused while infrastructure is migrated.
-PUBLIC_MAINTENANCE_SCHEDULED = 2026-02-25T10:00:00Z
-PUBLIC_MAINTENANCE_END = 2026-02-25T11:00:00Z
-PUBLIC_STATUS_PAGE_URL = https://status.sptfy.in
-```
-
-Then trigger a redeploy (push an empty commit or use Cloudflare dashboard).
-
-With `PUBLIC_MAINTENANCE_MODE=false`, maintenance auto-runs only inside the schedule window (`SCHEDULED` -> `END`).
-Manual overrides:
-
-- `PUBLIC_MAINTENANCE_MODE=true` forces maintenance ON immediately.
-- `PUBLIC_MAINTENANCE_MODE=off` forces maintenance OFF immediately.
-
-Supported `PUBLIC_MAINTENANCE_TYPE` values: `migration`, `database`, `infrastructure`, `security`, `incident`, `general`.
-Supported `PUBLIC_MAINTENANCE_MODE` values: `true`, `off`, `false` (or empty).
-
-**Verify:** Visit sptfy.in and confirm:
-
-- Maintenance toast appears
-- "Short It!" button is disabled
-- Existing redirects still work
-- "View server status" link opens your status page
-
-### 2.2 Stop Old PocketBase
+Run this before maintenance to reduce final cutover time.
 
 ```bash
-# SSH to old VPS
-ssh freq@<OLD_VPS_HOST_REDACTED>
+rsync -avz --progress OLD_USER@OLD_HOST:~/pb-docker/pb_data/ ~/pb-docker/pb_data/
+rsync -avz --progress OLD_USER@OLD_HOST:~/pb-docker/pb_public/ ~/pb-docker/pb_public/
+```
 
-# Stop PocketBase
+Notes:
+
+- Do not use `--delete` yet on warm sync.
+- A first warm sync may still copy active WAL files while old DB is live; that is expected.
+
+---
+
+## 3) Maintenance Window Setup
+
+Set maintenance env vars in Cloudflare Pages and redeploy.
+
+```env
+PUBLIC_MAINTENANCE_MODE=false
+PUBLIC_MAINTENANCE_TYPE=migration
+PUBLIC_MAINTENANCE_NOTE=Link creation is temporarily paused while infrastructure is migrated.
+PUBLIC_MAINTENANCE_SCHEDULED=<ISO timestamp>
+PUBLIC_MAINTENANCE_END=<ISO timestamp>
+PUBLIC_STATUS_PAGE_URL=https://status.sptfy.in
+```
+
+Mode behavior:
+
+- `PUBLIC_MAINTENANCE_MODE=true` -> force ON now
+- `PUBLIC_MAINTENANCE_MODE=off` -> force OFF now
+- `PUBLIC_MAINTENANCE_MODE=false` -> only ON inside scheduled window
+
+---
+
+## 4) Cutover (Short Freeze)
+
+This is the critical path. Keep it short and boring.
+
+### 4.1 Freeze writes
+
+1. Stop new PocketBase (avoid destination mutations during final sync):
+
+```bash
 cd ~/pb-docker
 docker compose down
-
-# Verify it's stopped
-docker ps
 ```
 
-### 2.3 Transfer Data to New VPS
-
-**Option A: Direct rsync (fastest)**
+2. Stop old PocketBase (authoritative write freeze):
 
 ```bash
-# From your local machine or old VPS
-rsync -avz --progress freq@<OLD_VPS_HOST_REDACTED>:~/pb-docker/ user@new-vps-ip:~/pb-docker/
+ssh OLD_USER@OLD_HOST 'cd ~/pb-docker && docker compose down'
 ```
 
-**Option B: Via your local machine**
+### 4.2 Fix destination permissions once
+
+If you previously synced as root or saw rsync code 23, run:
 
 ```bash
-# Download from old
-rsync -avz --progress freq@<OLD_VPS_HOST_REDACTED>:~/pb-docker/ ./pb-backup/
-
-# Upload to new
-rsync -avz --progress ./pb-backup/ user@new-vps-ip:~/pb-docker/
+sudo chown -R NEW_USER:NEW_USER /home/NEW_USER/pb-docker/pb_data /home/NEW_USER/pb-docker/pb_public
 ```
 
-**Option C: If rsync isn't available**
+### 4.3 Final authoritative sync
+
+Now use `--delete` so destination mirrors source exactly:
 
 ```bash
-# On old VPS
-cd ~
-tar -czvf pb-backup.tar.gz pb-docker/
-
-# Download locally
-scp freq@<OLD_VPS_HOST_REDACTED>:~/pb-backup.tar.gz .
-
-# Upload to new VPS
-scp pb-backup.tar.gz user@new-vps-ip:~/
-
-# On new VPS
-tar -xzvf pb-backup.tar.gz
+rsync -avz --delete --progress OLD_USER@OLD_HOST:~/pb-docker/pb_data/ /home/NEW_USER/pb-docker/pb_data/
+rsync -avz --delete --progress OLD_USER@OLD_HOST:~/pb-docker/pb_public/ /home/NEW_USER/pb-docker/pb_public/
 ```
 
-### 2.4 Start PocketBase on New VPS
+### 4.4 Start new backend
 
 ```bash
-# SSH to new VPS
-ssh user@new-vps-ip
-
 cd ~/pb-docker
 docker compose up -d
-
-# Verify it's running
-docker ps
-curl http://localhost:8091/api/health
+docker compose ps
+docker exec pocketbase /usr/local/bin/pocketbase --version
+curl -sf http://localhost:8091/api/health
+curl -sf https://pb.sptfy.in/api/health
 ```
 
-### 2.5 Test via sslip.io (Instant DNS)
+---
 
-Before switching DNS, test the new server using sslip.io:
+## 5) Go / No-Go Checklist
 
-```
-http://NEW_VPS_IP.sslip.io:8091/api/health
-```
+Do not lift maintenance until all pass:
 
-Or test a redirect:
+- [ ] `curl -sf http://localhost:8091/api/health`
+- [ ] `curl -sf https://pb.sptfy.in/api/health`
+- [ ] Admin panel loads at `https://pb.sptfy.in/_/`
+- [ ] Existing redirect works
+- [ ] New short link creation works
+- [ ] `/recent` and `/top` load correctly
 
-```
-http://NEW_VPS_IP.sslip.io:8091/YOUR_SHORT_SLUG
-```
+---
 
-**For HTTPS testing** (if you need it):
+## 6) GitHub Actions Update
 
-- sslip.io supports Let's Encrypt certificates via HTTP-01 challenge
-- You can temporarily configure your frontend to point to the sslip.io domain
+Workflow expects plain SSH host/user/key values:
 
-### 2.6 Update DNS
+- `VPS_HOST`: IP or DNS-only hostname (no `http://`, no path)
+- `VPS_USER`: SSH username (example: `freq-azure`)
+- `VPS_SSH_KEY`: full private key contents, including BEGIN/END lines
 
-**In Cloudflare DNS:**
+Cloudflare note:
 
-1. Find the A record for `pb.sptfy.in`
-2. Update the IP to your new VPS IP
-3. Keep Proxy Status: **DNS only** (gray cloud) for now
-4. Save
+- Do not use an orange-cloud proxy hostname for SSH.
+- Use raw IP or DNS-only hostname for `VPS_HOST`.
 
-**Check propagation:**
+---
+
+## 7) Post-Cutover Hardening
+
+1. In Azure NSG inbound rules:
+   - Keep only `22`, `80`, `443`
+   - Restrict SSH (`22`) source to `MY_PUBLIC_IP/32`
+2. Confirm `8091` is not publicly exposed
+3. Keep old VPS on standby for 24-72h (optional)
+4. Disable maintenance mode and redeploy frontend
+5. Monitor logs and health for 1-2 hours
+
+---
+
+## 8) Rollback (Fast)
+
+If anything fails after cutover:
 
 ```bash
-# Should return new IP
+# Stop new
+ssh NEW_USER@NEW_HOST 'cd ~/pb-docker && docker compose down'
+
+# Start old
+ssh OLD_USER@OLD_HOST 'cd ~/pb-docker && docker compose up -d'
+
+# Revert DNS if needed
+```
+
+Keep maintenance ON until old path is verified healthy.
+
+---
+
+## 9) Known Pitfalls
+
+- Hitting VM IP directly may show default Nginx page if your PocketBase block is domain-only (`server_name pb.sptfy.in`).
+- `rsync --delete` before write freeze can remove/replace files mid-write.
+- `rsync code 23` usually means destination permission mismatch; run `chown -R` then retry.
+- Avoid `latest` image tags during migration; pin exact version, upgrade later.
+
+---
+
+## 10) Useful Commands
+
+```bash
+# Health
+curl -sf http://localhost:8091/api/health
+curl -sf https://pb.sptfy.in/api/health
+
+# Compose
+cd ~/pb-docker
+docker compose ps
+docker compose logs -f
+docker compose restart
+
+# DNS checks
 dig +short pb.sptfy.in
 nslookup pb.sptfy.in
 ```
 
-Or use: https://www.whatsmydns.net/#A/pb.sptfy.in
-
-### 2.7 Update GitHub Actions Secrets
-
-If your deployment workflow uses VPS credentials:
-
-1. Go to GitHub → Settings → Secrets and variables → Actions
-2. Update these secrets with new VPS details:
-   - `VPS_HOST` (new IP)
-   - `VPS_USER` (if different)
-   - `VPS_SSH_KEY` (if different)
-
-### 2.8 Verify Everything Works
-
-```bash
-# Test PocketBase API via domain
-curl https://pb.sptfy.in/api/health
-
-# Test a redirect
-curl -I https://sptfy.in/YOUR_TEST_SLUG
-```
-
 ---
 
-## Phase 3: Post-Migration
+## 11) Session Close Checklist
 
-### 3.1 Disable Maintenance Mode
-
-**In Cloudflare Pages → Environment Variables:**
-
-```
-PUBLIC_MAINTENANCE_MODE = false
-PUBLIC_MAINTENANCE_TYPE = (clear/delete)
-PUBLIC_MAINTENANCE_NOTE = (clear/delete)
-PUBLIC_MAINTENANCE_SCHEDULED = (clear/delete)
-PUBLIC_MAINTENANCE_END = (clear/delete)
-PUBLIC_STATUS_PAGE_URL = (optional, keep default or clear)
-```
-
-If you need to immediately bypass a scheduled window, set `PUBLIC_MAINTENANCE_MODE = off`.
-
-Trigger redeploy.
-
-### 3.2 Verify Full Functionality
-
-- [ ] Create a new short link (homepage)
-- [ ] Create a short link (dashboard, if logged in)
-- [ ] Test a redirect
-- [ ] Check recent/top pages load
-
-### 3.3 Restore DNS TTL
-
-In Cloudflare DNS, set TTL back to **Auto** or your preferred value.
-
-### 3.4 Monitor for Issues
-
-Check for errors in:
-
-- Cloudflare Pages deployment logs
-- New VPS Docker logs: `docker compose logs -f`
-- BetterStack or your monitoring tool
-
----
-
-## Rollback Procedure
-
-If something goes wrong:
-
-### Quick Rollback (< 30 min into migration)
-
-```bash
-# Stop new VPS PocketBase
-ssh user@new-vps-ip
-cd ~/pb-docker && docker compose down
-
-# Restart old VPS PocketBase
-ssh freq@<OLD_VPS_HOST_REDACTED>
-cd ~/pb-docker && docker compose up -d
-
-# Revert DNS to old IP
-# (In Cloudflare DNS)
-
-# Keep maintenance mode on until confirmed working
-```
-
-### If Data Was Modified on New Server
-
-You'll need to decide:
-
-1. **Accept data loss**: Revert to old server, lose any links created on new
-2. **Forward-fix**: Debug and fix the issue on new server
-3. **Merge data**: Export new data, merge with old, restore (complex)
-
----
-
-## Emergency Contacts
-
-- **Primary**: @ayamkv
-- **Monitoring**: BetterStack status page
-
----
-
-## Appendix: Useful Commands
-
-### Docker Commands
-
-```bash
-# View logs
-docker compose logs -f
-
-# Restart PocketBase
-docker compose restart
-
-# Check container status
-docker ps
-
-# Enter container shell
-docker compose exec pocketbase sh
-```
-
-### PocketBase Admin
-
-- Admin UI: `https://pb.sptfy.in/_/`
-- API health: `https://pb.sptfy.in/api/health`
-
-### Cloudflare Pages
-
-- Dashboard: https://dash.cloudflare.com
-- Environment variables: Pages → sptfyin → Settings → Environment variables
-
-### Backup Locations
-
-- Automated backups: Cloudflare R2 (via PocketBase backup feature)
-- Manual backup on old VPS: `~/pb_backup_oct.zip`
+- [ ] Maintenance disabled
+- [ ] Traffic validated end-to-end
+- [ ] GH Action deploy tested once
+- [ ] SSH restricted to your IP
+- [ ] Old VPS decision recorded (keep/retire date)
+- [ ] Notes captured in PR/changelog


### PR DESCRIPTION
## Summary
- pin PocketBase Docker image in `docker-compose.yml` to `ghcr.io/muchobien/pocketbase:0.23.12` to avoid accidental version drift during migration
- replace the migration runbook with a v2 playbook that captures warm sync + short freeze cutover, go/no-go gates, rollback, and Azure hardening steps
- document GitHub Actions SSH secret format and Cloudflare proxy caveat for SSH host configuration

## Testing
- not run (docs/config-only change)