### PR TITLE
feat: cache homepage stats

### DIFF
--- a/src/lib/homeDataCache.js
+++ b/src/lib/homeDataCache.js
@@ -15,6 +15,9 @@ export async function getHomeData() {
 	}
 
 	const res = await fetch('/home-data.json');
+	if (!res.ok) {
+		throw new Error(`Failed to fetch home data: ${res.status}`);
+	}
 	const data = await res.json();
 
 	if (typeof localStorage !== 'undefined') {

--- a/src/lib/homeDataCache.js
+++ b/src/lib/homeDataCache.js
@@ -1,0 +1,41 @@
+const CACHE_KEY = 'sptfyin_home_data';
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+
+export async function getHomeData() {
+	if (typeof localStorage !== 'undefined') {
+		try {
+			const cached = localStorage.getItem(CACHE_KEY);
+			if (cached) {
+				const parsed = JSON.parse(cached);
+				if (parsed.expires > Date.now()) {
+					return parsed.data;
+				}
+			}
+		} catch {}
+	}
+
+	const res = await fetch('/home-data.json');
+	const data = await res.json();
+
+	if (typeof localStorage !== 'undefined') {
+		try {
+			localStorage.setItem(
+				CACHE_KEY,
+				JSON.stringify({
+					data,
+					expires: Date.now() + CACHE_TTL
+				})
+			);
+		} catch {}
+	}
+
+	return data;
+}
+
+export function clearHomeDataCache() {
+	if (typeof localStorage !== 'undefined') {
+		try {
+			localStorage.removeItem(CACHE_KEY);
+		} catch {}
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,12 @@
 	import { fade, slide } from 'svelte/transition';
 	import { toast } from 'svelte-sonner';
 	import { expoOut } from 'svelte/easing';
-	import { createRecord, generateRandomURL, isSlugAvailable } from '$lib/pocketbase';
+	import {
+		createRecord,
+		generateRandomURL,
+		getRecentRecords,
+		isSlugAvailable
+	} from '$lib/pocketbase';
 	import { clearHomeDataCache, getHomeData } from '$lib/homeDataCache';
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 	// import { generateRandomURL } from "$lib/utils";
@@ -182,11 +187,11 @@
 		recentLoading = true;
 		topLoading = true;
 		try {
-			const data = await getHomeData();
-			records = data.recent || [];
-			topRecords = data.top || [];
-			totalLinkCreated = data.totalLinkCreated;
-			totalClicks = data.totalClicks;
+			const [cachedData, recentResponse] = await Promise.all([getHomeData(), getRecentRecords()]);
+			topRecords = cachedData.top || [];
+			totalLinkCreated = cachedData.totalLinkCreated;
+			totalClicks = cachedData.totalClicks;
+			records = recentResponse.items;
 		} catch (error) {
 			console.error(error);
 			errorMessage = 'An error occurred while fetching data.';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,14 +7,8 @@
 	import { fade, slide } from 'svelte/transition';
 	import { toast } from 'svelte-sonner';
 	import { expoOut } from 'svelte/easing';
-	import {
-		createRecord,
-		getTotalClicks,
-		getRecentRecords,
-		getTopLinks,
-		generateRandomURL,
-		isSlugAvailable
-	} from '$lib/pocketbase';
+	import { createRecord, generateRandomURL, isSlugAvailable } from '$lib/pocketbase';
+	import { clearHomeDataCache, getHomeData } from '$lib/homeDataCache';
 	import * as ToggleGroup from '$lib/components/ui/toggle-group';
 	// import { generateRandomURL } from "$lib/utils";
 	import {
@@ -184,51 +178,30 @@
 	let totalLinkCreated = $state();
 	let totalClicks = $state();
 
-	async function fetchData() {
+	async function loadHomeData() {
 		recentLoading = true;
-		try {
-			const response = await getRecentRecords();
-			records = response.items;
-			totalLinkCreated = response.totalItems;
-		} catch (error) {
-			console.error(error);
-			errorMessage = 'An error occurred while fetching data.'; // Added error message handling
-		} finally {
-			recentLoading = false;
-		}
-
-		try {
-			const cresponse = await getTotalClicks();
-			totalClicks = cresponse.totalItems;
-
-			console.log('Analytics Records: ', cresponse);
-		} catch (error) {
-			console.error(error);
-			errorMessage = 'An error occurred while fetching data.'; // Added error message handling
-		}
-	}
-
-	async function fetchTopLinks() {
 		topLoading = true;
 		try {
-			const response = await getTopLinks(2, 1);
-			topRecords = response.items;
+			const data = await getHomeData();
+			records = data.recent || [];
+			topRecords = data.top || [];
+			totalLinkCreated = data.totalLinkCreated;
+			totalClicks = data.totalClicks;
 		} catch (error) {
-			console.error('Error fetching top links:', error);
+			console.error(error);
+			errorMessage = 'An error occurred while fetching data.';
 		} finally {
+			recentLoading = false;
 			topLoading = false;
 		}
 	}
 	onMount(async () => {
-		// Generate random URL on page load
 		preGeneratedUrlId = await generateRandomURL();
 		console.log(preGeneratedUrlId);
 
-		recordsPromise = await fetchData();
+		await loadHomeData();
+		recordsPromise = records;
 		rrecords = records;
-
-		// Fetch top links for the leaderboard tab
-		await fetchTopLinks();
 	});
 	function getBrowserName() {
 		const userAgent = navigator.userAgent;
@@ -611,6 +584,7 @@
 			};
 			records = [newRecord, ...records].slice(0, 2);
 			totalLinkCreated = (totalLinkCreated || 0) + 1;
+			clearHomeDataCache();
 
 			toast.promise(promise, {
 				class: 'my-toast',

--- a/src/routes/home-data.json/+server.js
+++ b/src/routes/home-data.json/+server.js
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+
+const pocketBaseURL = import.meta.env.VITE_POCKETBASE_URL;
+
+export async function GET({ fetch, setHeaders }) {
+	const [recentRes, clicksRes, topRes] = await Promise.all([
+		fetch(
+			`${pocketBaseURL}/api/collections/viewList/records?sort=-created&fields=id_url,from,created,subdomain&perPage=2&page=1`
+		),
+		fetch(`${pocketBaseURL}/api/collections/analytics/records?perPage=1&page=1&fields=id`),
+		fetch(
+			`${pocketBaseURL}/api/collections/viewList/records?sort=-utm_view&fields=id_url,from,created,subdomain,utm_view&perPage=2&page=1&filter=(utm_view>0)`
+		)
+	]);
+
+	const [recentData, clicksData, topData] = await Promise.all([
+		recentRes.json(),
+		clicksRes.json(),
+		topRes.json()
+	]);
+
+	setHeaders({
+		'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800'
+	});
+
+	return json({
+		totalLinkCreated: recentData.totalItems || 0,
+		totalClicks: clicksData.totalItems || 0,
+		recent: (recentData.items || []).slice(0, 2),
+		top: (topData.items || []).slice(0, 2)
+	});
+}

--- a/src/routes/home-data.json/+server.js
+++ b/src/routes/home-data.json/+server.js
@@ -1,20 +1,22 @@
-import { json } from '@sveltejs/kit';
+import { error, json } from '@sveltejs/kit';
 
 const pocketBaseURL = import.meta.env.VITE_POCKETBASE_URL;
 
 export async function GET({ fetch, setHeaders }) {
-	const [recentRes, clicksRes, topRes] = await Promise.all([
-		fetch(
-			`${pocketBaseURL}/api/collections/viewList/records?sort=-created&fields=id_url,from,created,subdomain&perPage=2&page=1`
-		),
+	const [countRes, clicksRes, topRes] = await Promise.all([
+		fetch(`${pocketBaseURL}/api/collections/viewList/records?perPage=1&page=1&fields=id`),
 		fetch(`${pocketBaseURL}/api/collections/analytics/records?perPage=1&page=1&fields=id`),
 		fetch(
 			`${pocketBaseURL}/api/collections/viewList/records?sort=-utm_view&fields=id_url,from,created,subdomain,utm_view&perPage=2&page=1&filter=(utm_view>0)`
 		)
 	]);
 
-	const [recentData, clicksData, topData] = await Promise.all([
-		recentRes.json(),
+	if (!countRes.ok || !clicksRes.ok || !topRes.ok) {
+		error(502, 'Failed to fetch data from PocketBase');
+	}
+
+	const [countData, clicksData, topData] = await Promise.all([
+		countRes.json(),
 		clicksRes.json(),
 		topRes.json()
 	]);
@@ -24,9 +26,8 @@ export async function GET({ fetch, setHeaders }) {
 	});
 
 	return json({
-		totalLinkCreated: recentData.totalItems || 0,
+		totalLinkCreated: countData.totalItems || 0,
 		totalClicks: clicksData.totalItems || 0,
-		recent: (recentData.items || []).slice(0, 2),
 		top: (topData.items || []).slice(0, 2)
 	});
 }

--- a/src/routes/home-data.json/server.test.js
+++ b/src/routes/home-data.json/server.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GET } from './+server.js';
+
+function createMockFetch(recentItems, analyticsTotal, topItems) {
+	return vi.fn(async (url) => {
+		const urlStr = typeof url === 'string' ? url : url.toString();
+
+		if (urlStr.includes('viewList') && urlStr.includes('sort=-utm_view')) {
+			return {
+				json: async () => ({
+					items: topItems || [],
+					totalItems: topItems?.length || 0
+				})
+			};
+		}
+		if (urlStr.includes('analytics')) {
+			return {
+				json: async () => ({
+					items: [],
+					totalItems: analyticsTotal || 0
+				})
+			};
+		}
+		// Default: viewList recent
+		return {
+			json: async () => ({
+				items: recentItems || [],
+				totalItems: recentItems?.length || 0
+			})
+		};
+	});
+}
+
+describe('GET /home-data.json', () => {
+	it('returns combined homepage data', async () => {
+		const recentItems = [
+			{
+				id_url: 'abc1',
+				from: 'https://spotify.com/track/1',
+				created: '2026-01-01',
+				subdomain: 'sptfy.in'
+			},
+			{
+				id_url: 'abc2',
+				from: 'https://spotify.com/track/2',
+				created: '2026-01-02',
+				subdomain: 'sptfy.in'
+			}
+		];
+		const topItems = [
+			{
+				id_url: 'top1',
+				from: 'https://spotify.com/track/3',
+				created: '2026-01-01',
+				subdomain: 'sptfy.in',
+				utm_view: 100
+			}
+		];
+
+		const mockFetch = createMockFetch(recentItems, 500, topItems);
+
+		const response = await GET({ fetch: mockFetch, setHeaders: vi.fn() });
+		const data = await response.json();
+
+		expect(data.totalLinkCreated).toBe(2);
+		expect(data.totalClicks).toBe(500);
+		expect(data.recent).toHaveLength(2);
+		expect(data.top).toHaveLength(1);
+		expect(data.recent[0].id_url).toBe('abc1');
+		expect(data.top[0].utm_view).toBe(100);
+	});
+
+	it('handles empty state gracefully', async () => {
+		const mockFetch = createMockFetch([], 0, []);
+
+		const response = await GET({ fetch: mockFetch, setHeaders: vi.fn() });
+		const data = await response.json();
+
+		expect(data.totalLinkCreated).toBe(0);
+		expect(data.totalClicks).toBe(0);
+		expect(data.recent).toHaveLength(0);
+		expect(data.top).toHaveLength(0);
+	});
+
+	it('sets cache headers', async () => {
+		const setHeaders = vi.fn();
+		const mockFetch = createMockFetch([], 0, []);
+
+		await GET({ fetch: mockFetch, setHeaders });
+
+		expect(setHeaders).toHaveBeenCalledWith({
+			'Cache-Control': expect.stringContaining('max-age=86400')
+		});
+	});
+});

--- a/src/routes/home-data.json/server.test.js
+++ b/src/routes/home-data.json/server.test.js
@@ -1,52 +1,40 @@
 import { describe, expect, it, vi } from 'vitest';
 import { GET } from './+server.js';
 
-function createMockFetch(recentItems, analyticsTotal, topItems) {
+function mockResponse(body, ok = true, status = 200) {
+	return {
+		ok,
+		status,
+		json: async () => body
+	};
+}
+
+function createMockFetch(viewListTotal, analyticsTotal, topItems) {
 	return vi.fn(async (url) => {
 		const urlStr = typeof url === 'string' ? url : url.toString();
 
 		if (urlStr.includes('viewList') && urlStr.includes('sort=-utm_view')) {
-			return {
-				json: async () => ({
-					items: topItems || [],
-					totalItems: topItems?.length || 0
-				})
-			};
+			return mockResponse({
+				items: topItems || [],
+				totalItems: topItems?.length || 0
+			});
 		}
 		if (urlStr.includes('analytics')) {
-			return {
-				json: async () => ({
-					items: [],
-					totalItems: analyticsTotal || 0
-				})
-			};
+			return mockResponse({
+				items: [],
+				totalItems: analyticsTotal || 0
+			});
 		}
-		// Default: viewList recent
-		return {
-			json: async () => ({
-				items: recentItems || [],
-				totalItems: recentItems?.length || 0
-			})
-		};
+		// Default: viewList count
+		return mockResponse({
+			items: [],
+			totalItems: viewListTotal || 0
+		});
 	});
 }
 
 describe('GET /home-data.json', () => {
-	it('returns combined homepage data', async () => {
-		const recentItems = [
-			{
-				id_url: 'abc1',
-				from: 'https://spotify.com/track/1',
-				created: '2026-01-01',
-				subdomain: 'sptfy.in'
-			},
-			{
-				id_url: 'abc2',
-				from: 'https://spotify.com/track/2',
-				created: '2026-01-02',
-				subdomain: 'sptfy.in'
-			}
-		];
+	it('returns counters and top links', async () => {
 		const topItems = [
 			{
 				id_url: 'top1',
@@ -57,34 +45,47 @@ describe('GET /home-data.json', () => {
 			}
 		];
 
-		const mockFetch = createMockFetch(recentItems, 500, topItems);
+		const mockFetch = createMockFetch(42, 500, topItems);
 
 		const response = await GET({ fetch: mockFetch, setHeaders: vi.fn() });
 		const data = await response.json();
 
-		expect(data.totalLinkCreated).toBe(2);
+		expect(data.totalLinkCreated).toBe(42);
 		expect(data.totalClicks).toBe(500);
-		expect(data.recent).toHaveLength(2);
 		expect(data.top).toHaveLength(1);
-		expect(data.recent[0].id_url).toBe('abc1');
 		expect(data.top[0].utm_view).toBe(100);
 	});
 
+	it('does not include recent field', async () => {
+		const mockFetch = createMockFetch(0, 0, []);
+
+		const response = await GET({ fetch: mockFetch, setHeaders: vi.fn() });
+		const data = await response.json();
+
+		expect(data).not.toHaveProperty('recent');
+	});
+
 	it('handles empty state gracefully', async () => {
-		const mockFetch = createMockFetch([], 0, []);
+		const mockFetch = createMockFetch(0, 0, []);
 
 		const response = await GET({ fetch: mockFetch, setHeaders: vi.fn() });
 		const data = await response.json();
 
 		expect(data.totalLinkCreated).toBe(0);
 		expect(data.totalClicks).toBe(0);
-		expect(data.recent).toHaveLength(0);
 		expect(data.top).toHaveLength(0);
+	});
+
+	it('throws 502 on PocketBase failure', async () => {
+		await expect(async () => {
+			const fetch = vi.fn().mockResolvedValue(mockResponse({}, false, 502));
+			await GET({ fetch, setHeaders: vi.fn() });
+		}).rejects.toThrow();
 	});
 
 	it('sets cache headers', async () => {
 		const setHeaders = vi.fn();
-		const mockFetch = createMockFetch([], 0, []);
+		const mockFetch = createMockFetch(0, 0, []);
 
 		await GET({ fetch: mockFetch, setHeaders });
 


### PR DESCRIPTION
## Summary
Cache public homepage stats/recent/top data behind one JSON endpoint and browser localStorage to avoid repeated PocketBase hits on every homepage mount.

## Changes
- Add /home-data.json endpoint with 24h public/CDN caching.
- Add client localStorage cache helper with a 24h TTL.
- Update homepage to fetch one cached payload instead of three direct PocketBase requests.
- Clear the local cache after successful link creation.
- Add endpoint tests.

## Testing
- [x] pnpm test
- [x] pnpm build
- [x] pnpm prettier --check changed files
- [ ] pnpm lint (repo-wide currently has pre-existing formatting warnings outside this change)